### PR TITLE
Add 'clearAll' method in SamlPanelInfo to clear all labels before displaying new values.

### DIFF
--- a/src/main/java/application/SamlTabController.java
+++ b/src/main/java/application/SamlTabController.java
@@ -331,6 +331,7 @@ public class SamlTabController implements IMessageEditorTab, Observer {
 
 	private void setInformationDisplay() {
 		SamlPanelInfo infoPanel = samlGUI.getInfoPanel();
+		infoPanel.clearAll();
 
 		try {
 			Document document = xmlHelpers.getXMLDocumentOfSAMLMessage(SAMLMessage);

--- a/src/main/java/gui/SamlPanelInfo.java
+++ b/src/main/java/gui/SamlPanelInfo.java
@@ -214,11 +214,7 @@ public class SamlPanelInfo extends JPanel {
 		gbc_lblEncryption.gridy = 11;
 		add(lblEncryption, gbc_lblEncryption);
 	}
-	
-	public void setAssertionTitle(String string){
-		lblAssertionTitle.setText(string);
-	}
-	
+
 	public void setIssuer(String string){
 		lblIssuer.setText(string);
 	}
@@ -254,5 +250,16 @@ public class SamlPanelInfo extends JPanel {
 	public void setEncryptionAlgorithm(String string){
 		lblEncryption.setText(string);
 	}
-	
+
+	public void clearAll(){
+		setIssuer("");
+		setSubject("");
+		setConditionNotBefore("");
+		setConditionNotAfter("");
+		setSubjectConfNotBefore("");
+		setSubjectConfNotAfter("");
+		setSignatureAlgorithm("");
+		setDigestAlgorithm("");
+		setEncryptionAlgorithm("");
+	}
 }


### PR DESCRIPTION
Fixes #32 (tested and validated)